### PR TITLE
Pass correct oldValue to emitInputEvent for Slider

### DIFF
--- a/src/components/__tests__/Slider.spec.js
+++ b/src/components/__tests__/Slider.spec.js
@@ -2,7 +2,19 @@ import Slider from '../slider';
 import { mount } from '@vue/test-utils';
 
 const mountComponent = (options = {}) => {
-  return mount(Slider, options);
+  const component = mount(Slider, options);
+  // Mock the slider rect to properly simulate position changes
+  component.vm.$refs.slider.getBoundingClientRect = () => {
+    return {
+      bottom: 20,
+      height: 20,
+      left: 0,
+      right: 100,
+      top: 0,
+      width: 100
+    }
+  };
+  return component;
 }
 
 let wrapper = null
@@ -17,7 +29,7 @@ it('renders correctly', () => {
 });
 
 it('renders vertically', () => {
-  wrapper = mountComponent({ 
+  wrapper = mountComponent({
     propsData: {
       vertical: true
     }
@@ -26,7 +38,7 @@ it('renders vertically', () => {
 });
 
 it('renders inverted', () => {
-  wrapper = mountComponent({ 
+  wrapper = mountComponent({
     propsData: {
       inverted: true
     }
@@ -35,7 +47,7 @@ it('renders inverted', () => {
 });
 
 it('renders disabled', () => {
-  wrapper = mountComponent({ 
+  wrapper = mountComponent({
     propsData: {
       disabled: true
     }
@@ -59,13 +71,13 @@ it('should change value on key press', () => {
   expect(wrapper.vm.localValue).toBe(10);
 
   wrapper.trigger('keydown.pagedown');
-  
+
   expect(wrapper.vm.localValue).toBe(0);
 
   wrapper.trigger('keydown.end');
-  
+
   expect(wrapper.vm.localValue).toBe(100);
-  
+
   wrapper.trigger('keydown.home');
 
   expect(wrapper.vm.localValue).toBe(0);
@@ -102,6 +114,7 @@ it('should emit change event slide start', () => {
 
   wrapper.trigger('mousedown');
   expect(wrapper.emitted().change).toBeDefined();
+  expect(wrapper.emitted().input).toBeUndefined();
 })
 
 it('should emit change event slide end', () => {
@@ -110,5 +123,24 @@ it('should emit change event slide end', () => {
   wrapper.trigger('touchstart');
   wrapper.trigger('touchend');
   expect(wrapper.emitted().change).toBeDefined();
+  expect(wrapper.emitted().input).toBeUndefined();
 })
 
+it('should emit input event delta slide start', () => {
+  wrapper = mountComponent();
+
+  const mouseEvent = {clientX: 50, clientY: 0};
+  wrapper.trigger('mouseenter', mouseEvent);
+  wrapper.trigger('mousedown', mouseEvent);
+  expect(wrapper.emitted().change).toBeDefined();
+  expect(wrapper.emitted().input).toBeDefined();
+})
+
+it('should emit input event delta slide end', () => {
+  wrapper = mountComponent();
+
+  wrapper.trigger('touchstart', {touches: [{clientX: 50, clientY: 0}]});
+  wrapper.trigger('touchend');
+  expect(wrapper.emitted().change).toBeDefined();
+  expect(wrapper.emitted().input).toBeDefined();
+})

--- a/src/components/base-slider.js
+++ b/src/components/base-slider.js
@@ -295,7 +295,7 @@ export default Vue.extend({
       if (this.shouldInvertMouseCoords()) {
         percent = 1 - percent;
       }
-      
+
       let value;
 
       // Since the steps may not divide cleanly into the max value, if the user
@@ -396,7 +396,7 @@ export default Vue.extend({
       return ((value || 0) - this.min) / (this.max - this.min);
     },
     emitChangeEvent() {
-      this.$emit("change", this.localValue);  
+      this.$emit("change", this.localValue);
     },
     emitInputEvent(newValue, oldValue) {
       if (newValue != oldValue) {
@@ -430,10 +430,12 @@ export default Vue.extend({
           value = parseFloat(value.toFixed(this.roundToDecimal));
         }
 
+        const oldValue = this.localValue;
+
         this.localValue = value;
         this.localPercent = this.calculatePercentage(this.localValue);
-      
-        this.emitInputEvent(this.localValue, v);
+
+        this.emitInputEvent(this.localValue, oldValue);
       }
     },
     createSlider() {
@@ -486,32 +488,32 @@ export default Vue.extend({
     createTrack() {
       const h = this.$createElement;
 
-      const background = h('div', { 
+      const background = h('div', {
         staticClass: 'slider-track-background',
         style: this.trackBackgroundStyles(this.percent)
       });
 
-      return h('div', { 
+      return h('div', {
         staticClass: 'slider-track-wrapper'
       }, [background, this.createTrackFill(this.percent)]);
     },
     createThumb(percent, listeners = {}, isActive = this.isActive) {
       const h = this.$createElement;
 
-      const thumbText = isActive 
-        ? h('span', { 
-            staticClass: 'slider-thumb-label-text' 
-          }, this.displayValue) 
+      const thumbText = isActive
+        ? h('span', {
+            staticClass: 'slider-thumb-label-text'
+          }, this.displayValue)
         : h();
       const focusEl = h('div', { staticClass: 'slider-focus-ring' });
       const thumb = h('div', { staticClass: 'slider-thumb' });
       const thumbLabel = h('div', { staticClass: 'slider-thumb-label' }, [thumbText]);
 
-      return h('div', { 
-        staticClass: 'slider-thumb-container', 
-        class: { 
-          'slider-thumb-active': isActive,          
-          'slider-min-value': this.isMinValue, 
+      return h('div', {
+        staticClass: 'slider-thumb-container',
+        class: {
+          'slider-thumb-active': isActive,
+          'slider-min-value': this.isMinValue,
         },
         style: this.thumbContainerStyles(percent),
         on: { ...listeners },


### PR DESCRIPTION
Input events do not work correctly for the Slider component. The issue stems from the incorrect oldValue being passed for change comparison. This breaks input reactivity for `v-model`. The RangeSlider is correctly implemented.