### PR TITLE
Use CSS variables for thumb gap rather than hard-coded JS constants

### DIFF
--- a/src/components/__tests__/__snapshots__/Slider.spec.js.snap
+++ b/src/components/__tests__/__snapshots__/Slider.spec.js.snap
@@ -4,8 +4,8 @@ exports[`renders correctly 1`] = `
 <div class="slider slider-horizontal">
   <div class="slider-wrapper">
     <div class="slider-track-wrapper">
-      <div class="slider-track-background" style="transform: translateX(7px) scale3d(1, 1, 1);"></div>
-      <div class="slider-track-fill" style="transform: translateX(-7px) scale3d(0, 1, 1);"></div>
+      <div class="slider-track-background" style="transform: translateX(var(--min-value-nonactive-thumb-gap, 7px)) scale3d(1, 1, 1);"></div>
+      <div class="slider-track-fill" style="transform: translateX(calc(0px - var(--min-value-nonactive-thumb-gap, 7px))) scale3d(0, 1, 1);"></div>
     </div>
     <div tabindex="0" class="slider-thumb-container slider-min-value" style="transform: translateX(-100%);">
       <div class="slider-focus-ring"></div>
@@ -22,8 +22,8 @@ exports[`renders disabled 1`] = `
 <div class="slider slider-disabled slider-horizontal">
   <div class="slider-wrapper">
     <div class="slider-track-wrapper">
-      <div class="slider-track-background" style="transform: translateX(7px) scale3d(1, 1, 1);"></div>
-      <div class="slider-track-fill" style="transform: translateX(-7px) scale3d(0, 1, 1);"></div>
+      <div class="slider-track-background" style="transform: translateX(var(--disabled-thumb-gap, 7px)) scale3d(1, 1, 1);"></div>
+      <div class="slider-track-fill" style="transform: translateX(calc(0px - var(--disabled-thumb-gap, 7px))) scale3d(0, 1, 1);"></div>
     </div>
     <div tabindex="0" class="slider-thumb-container slider-min-value" style="transform: translateX(-100%);">
       <div class="slider-focus-ring"></div>
@@ -40,8 +40,8 @@ exports[`renders inverted 1`] = `
 <div class="slider slider-horizontal" inverted="true">
   <div class="slider-wrapper">
     <div class="slider-track-wrapper">
-      <div class="slider-track-background" style="transform: translateX(7px) scale3d(1, 1, 1);"></div>
-      <div class="slider-track-fill" style="transform: translateX(-7px) scale3d(0, 1, 1);"></div>
+      <div class="slider-track-background" style="transform: translateX(var(--min-value-nonactive-thumb-gap, 7px)) scale3d(1, 1, 1);"></div>
+      <div class="slider-track-fill" style="transform: translateX(calc(0px - var(--min-value-nonactive-thumb-gap, 7px))) scale3d(0, 1, 1);"></div>
     </div>
     <div tabindex="0" class="slider-thumb-container slider-min-value" style="transform: translateX(-100%);">
       <div class="slider-focus-ring"></div>
@@ -58,8 +58,8 @@ exports[`renders vertically 1`] = `
 <div class="slider slider-vertical slider-axis-inverted">
   <div class="slider-wrapper">
     <div class="slider-track-wrapper">
-      <div class="slider-track-background" style="transform: translateY(-7px) scale3d(1, 1, 1);"></div>
-      <div class="slider-track-fill" style="transform: translateY(7px) scale3d(1, 0, 1);"></div>
+      <div class="slider-track-background" style="transform: translateY(calc(0px - var(--min-value-nonactive-thumb-gap, 7px))) scale3d(1, 1, 1);"></div>
+      <div class="slider-track-fill" style="transform: translateY(var(--min-value-nonactive-thumb-gap, 7px)) scale3d(1, 0, 1);"></div>
     </div>
     <div tabindex="0" class="slider-thumb-container slider-min-value" style="transform: translateY(-0%);">
       <div class="slider-focus-ring"></div>

--- a/src/components/slider.scss
+++ b/src/components/slider.scss
@@ -5,6 +5,9 @@
   padding: 8px;
   outline: 0;
   vertical-align: middle;
+  --disabled-thumb-gap: 7px;
+  --min-value-nonactive-thumb-gap: 7px;
+  --min-value-active-thumb-gap: 10px;
 }
 
 .slider-wrapper {


### PR DESCRIPTION
Adds some extra flexibility for CSS theming by defining thumb gap metrics as CSS variables rather than JS constants.

Here is an example where the overall scale of the slider is doubled:

```html
  <vue-material-slider class="double-size-slider"/>
```
```css
.double-size-slider {
  min-height: 256px;
  margin: 32px;
  --disabled-thumb-gap: 14px;
  --min-value-nonactive-thumb-gap: 14px;
  --min-value-active-thumb-gap: 20px;
  .slider-thumb {
    right: -20px;
    bottom: -20px;
    width: 40px;
    height: 40px;
  }
  .slider-track-wrapper {
    width: 4px;
    left: -1px;
  }
  .slider-track-background {
    width: 4px;
  }
  .slider-track-fill {
    width: 4px;
  }
}
```